### PR TITLE
Trying different cert handling

### DIFF
--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -80,8 +80,7 @@ RUN --mount=type=secret,id=fullchain_pem \
     install -d -m 755 /etc/ssl/certs && \
     cp /run/secrets/fullchain_pem /etc/ssl/certs/fullchain.pem && \
     chown root:node /etc/ssl/certs /etc/ssl/certs/fullchain.pem && \
-    chmod 444 /etc/ssl/certs/fullchain.pem && \
-    usermod -aG node node
+    chmod 444 /etc/ssl/certs/fullchain.pem
 
 # Updating npm did not fix this issue, though it might at a future date.
 # Fix Your cache folder contains root-owned files, due to a bug in previous versions of npm which has since been addressed.


### PR DESCRIPTION
Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
